### PR TITLE
Add bespoke encoding format

### DIFF
--- a/packages/encoding/package.json
+++ b/packages/encoding/package.json
@@ -11,9 +11,11 @@
     "graphql": "^14.2.1",
     "graphql-query-compress": "^1.2.1",
     "msgpack5": "^4.2.1",
-    "protobufjs": "^6.8.8"
+    "protobufjs": "^6.8.8",
+    "varint": "^5.0.0"
   },
   "devDependencies": {
-    "@types/msgpack5": "^3.4.1"
+    "@types/msgpack5": "^3.4.1",
+    "@types/varint": "^5.0.0"
   }
 }

--- a/packages/encoding/src/RequestEncoder.ts
+++ b/packages/encoding/src/RequestEncoder.ts
@@ -1,5 +1,5 @@
 import { GraphQLSchema } from "graphql";
-import * as impl from './impl/proto';
+import * as impl from './impl/bespoke';
 
 export default class RequestEncoder {
     constructor(private schema: GraphQLSchema, private implementation = impl) {}

--- a/packages/encoding/src/__tests__/__snapshots__/RequestEncoder.test.ts.snap
+++ b/packages/encoding/src/__tests__/__snapshots__/RequestEncoder.test.ts.snap
@@ -3,26 +3,26 @@
 exports[`encoding minimal encoding query "all.graphql" 1`] = `
 Object {
   "baselineSize": 67,
-  "difference": "79.10%",
-  "optimizedDifference": "79.10%",
-  "size": 14,
+  "difference": "92.54%",
+  "optimizedDifference": "92.54%",
+  "size": 5,
 }
 `;
 
 exports[`encoding minimal encoding query "nested.graphql" 1`] = `
 Object {
   "baselineSize": 205,
-  "difference": "75.61%",
-  "optimizedDifference": "28.57%",
-  "size": 50,
+  "difference": "91.71%",
+  "optimizedDifference": "75.71%",
+  "size": 17,
 }
 `;
 
 exports[`encoding minimal encoding query "one.graphql" 1`] = `
 Object {
   "baselineSize": 26,
-  "difference": "92.31%",
-  "optimizedDifference": "92.31%",
-  "size": 2,
+  "difference": "96.15%",
+  "optimizedDifference": "96.15%",
+  "size": 1,
 }
 `;

--- a/packages/encoding/src/impl/bespoke.ts
+++ b/packages/encoding/src/impl/bespoke.ts
@@ -1,0 +1,153 @@
+import path from 'path';
+import varint from 'varint';
+import { parse, GraphQLSchema, OperationDefinitionNode, FieldNode } from 'graphql';
+
+function resolveType(node: any): any {
+    if (node.ofType) {
+        return resolveType(node.ofType);
+    }
+
+    if (node.type && node.type.ofType) {
+        return resolveType(node.type.ofType);
+    }
+
+    if (node.type) {
+        return resolveType(node.type);
+    }
+
+    return node;
+}
+
+const TYPE_QUERY = 0;
+const TYPE_MUTATION = 1;
+const TYPE_SUBSCRIPTION = 2;
+
+const FIELD_EXIT = 3;
+// Use an enter offset to make it unambiguous with query (0) mutation (1) subscription (2) and pop (3)
+const FIELD_ENTER_OFFSET = 4;
+
+export function encode(schema: GraphQLSchema, query: string) {
+    // TODO: Don't do fixed size:
+    const data: number[] = [];
+
+    const requestDescription: any = {
+        fields: 0
+    };
+
+    const parsedQuery = parse(query);
+
+    const operationDefinition = parsedQuery.definitions[0] as OperationDefinitionNode;
+
+    function write(num: number) {
+        varint.encode(num).forEach(byte => {
+            data.push(byte);
+        });
+    }
+
+    function optimizeQuery() {
+        let i = data.length - 1;
+        while (data[i] === FIELD_EXIT) {
+            data.splice(i, 1);
+            i--;
+        }
+    }
+
+    function walkSelections(selectionDescription: any, node: FieldNode, schemaNode: any) {
+        const selections = node.selectionSet!.selections;
+        const schemaFields = schemaNode.getFields();
+
+        selections.forEach((selection, i) => {
+            if (selection.kind !== 'Field') {
+                throw new Error('Only field selections are currently supported.');
+            }
+
+            const selectionNode = schemaFields[selection.name.value];
+            const fieldDirective = selectionNode.astNode.directives.find(
+                (dir: any) => dir.name.value === 'field'
+            );
+            // Only ever has one argument right now:
+            const fieldNumber = parseInt(fieldDirective.arguments[0].value.value, 10) - 1;
+
+            selectionDescription.fields |= 1 << fieldNumber;
+        });
+
+        write(selectionDescription.fields);
+
+        selections.forEach(selection => {
+            if (selection.kind !== 'Field') {
+                throw new Error('Only field selections are currently supported.');
+            }
+
+            const selectionNode = schemaFields[selection.name.value];
+            const fieldDirective = selectionNode.astNode.directives.find(
+                (dir: any) => dir.name.value === 'field'
+            );
+            // Only ever has one argument right now:
+            const fieldNumber = parseInt(fieldDirective.arguments[0].value.value, 10) - 1;
+
+            if (selection.selectionSet) {
+                write(fieldNumber + 1 + FIELD_ENTER_OFFSET);
+                if (!selectionDescription.selections) {
+                    selectionDescription.selections = [];
+                }
+
+                const data = { field: fieldNumber, fields: 0 };
+                selectionDescription.selections.push(data);
+
+                walkSelections(
+                    data,
+                    selection,
+                    resolveType(schemaNode.getFields()[selection.name.value])
+                );
+
+                write(FIELD_EXIT);
+            }
+        });
+    }
+
+    walkSelections(requestDescription, operationDefinition as any, schema.getQueryType());
+
+    switch (operationDefinition.operation) {
+        case 'mutation':
+            write(TYPE_MUTATION);
+            break;
+        case 'subscription':
+            write(TYPE_SUBSCRIPTION);
+            break;
+        case 'query':
+            // For query, we can actually optimize by ditching any trailing pops:
+            optimizeQuery();
+            break;
+        default:
+            throw new Error();
+            break;
+    }
+
+    return Buffer.from(data);
+}
+
+// NOTE: This isn't complete, it's just a proof-of-concept:
+function decode(data: number[]) {
+    const root: any = {};
+    let offset = 0;
+
+    function resolveField(selection = root) {
+        selection.fields = varint.decode(data, offset);
+        offset += varint.decode.bytes;
+
+        if (data[offset]) {
+            // We're pushing a field:
+            if (data[offset] > FIELD_ENTER_OFFSET) {
+                selection.children = selection.children || {};
+                const field = varint.decode(data, offset) - FIELD_ENTER_OFFSET;
+                offset += varint.decode.bytes;
+                selection.children[field] = {};
+                resolveField(selection.children[field]);
+            }
+        }
+    }
+
+    resolveField();
+
+    return root;
+}

--- a/packages/encoding/src/impl/proto.ts
+++ b/packages/encoding/src/impl/proto.ts
@@ -79,7 +79,9 @@ export function encode(schema: GraphQLSchema, query: string) {
 
     walkSelections(requestDescription, operationDefinition as any, schema.getQueryType());
 
-    const buf =  Request.encode(Request.fromObject(requestDescription)).finish();
+    console.log(requestDescription);
+
+    const buf = Request.encode(Request.fromObject(requestDescription)).finish();
 
     // @ts-ignore
     // console.log(Request.decode(buf).selection);

--- a/yarn.lock
+++ b/yarn.lock
@@ -425,6 +425,13 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
+"@types/varint@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@types/varint/-/varint-5.0.0.tgz#f667321775101a92d5c401f87a04274282538202"
+  integrity sha512-dIJiYqeDnYQ5Bc4mv+E5prqFIQlUTM1yDzwC5VQfL29pcYlm/5q1shY/MjbBT1FQAU5gzKE10DdGbu8B2EoFQg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/yargs@^12.0.2", "@types/yargs@^12.0.9":
   version "12.0.12"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-12.0.12.tgz#45dd1d0638e8c8f153e87d296907659296873916"
@@ -3663,6 +3670,11 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+varint@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/varint/-/varint-5.0.0.tgz#d826b89f7490732fabc0c0ed693ed475dcb29ebf"
+  integrity sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8=
 
 verror@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
This adds a new bespoke encoding format. Here's an overview of how the encoding works:

1. Root field selections (varint)
2. Nested selection enter tag (tagged varint)
3. Nested field selections (optional, varint)
4. Nested selection exit tag (byte)
5. Type of query (optional, query or mutation)
