### PR TITLE
Unify Intermediate Representation

### DIFF
--- a/packages/encoding/src/RequestEncoder.ts
+++ b/packages/encoding/src/RequestEncoder.ts
@@ -1,10 +1,11 @@
 import { GraphQLSchema } from "graphql";
 import * as impl from './impl/bespoke';
+import { Variables } from "./types";
 
 export default class RequestEncoder {
     constructor(private schema: GraphQLSchema, private implementation = impl) {}
 
-    encode(query: string, variables?: any): Buffer | Uint8Array {
+    encode(query: string, variables: Variables): Buffer | Uint8Array {
         return this.implementation.encode(this.schema, query, variables);
     }
 }

--- a/packages/encoding/src/__tests__/__snapshots__/RequestEncoder.test.ts.snap
+++ b/packages/encoding/src/__tests__/__snapshots__/RequestEncoder.test.ts.snap
@@ -12,18 +12,18 @@ Object {
 exports[`encoding minimal encoding query "arguments.graphql" 1`] = `
 Object {
   "baselineSize": 77,
-  "difference": "81.82%",
-  "optimizedDifference": "81.82%",
-  "size": 14,
+  "difference": "83.12%",
+  "optimizedDifference": "83.12%",
+  "size": 13,
 }
 `;
 
 exports[`encoding minimal encoding query "multiple-arguments.graphql" 1`] = `
 Object {
   "baselineSize": 170,
-  "difference": "77.65%",
-  "optimizedDifference": "72.86%",
-  "size": 38,
+  "difference": "62.35%",
+  "optimizedDifference": "54.29%",
+  "size": 64,
 }
 `;
 
@@ -48,8 +48,8 @@ Object {
 exports[`encoding minimal encoding query "variables.graphql" 1`] = `
 Object {
   "baselineSize": 265,
-  "difference": "85.66%",
-  "optimizedDifference": "79.68%",
-  "size": 38,
+  "difference": "76.60%",
+  "optimizedDifference": "66.84%",
+  "size": 62,
 }
 `;

--- a/packages/encoding/src/createIR.ts
+++ b/packages/encoding/src/createIR.ts
@@ -1,0 +1,135 @@
+import {
+    GraphQLSchema,
+    parse,
+    FieldNode,
+    InputValueDefinitionNode,
+    ArgumentNode,
+    OperationDefinitionNode
+} from 'graphql';
+import { Variables } from './types';
+
+export type ArgumentIR = {
+    arg: number;
+    value: Buffer | null;
+};
+
+export type ChildIR = {
+    id: number;
+    fields: number;
+    arguments?: ArgumentIR[];
+    selections?: ChildIR[];
+};
+
+export type IR<Type = any> = {
+    type: Type;
+    fields: number;
+    selections?: ChildIR[];
+};
+
+function resolveType(node: any): any {
+    if (node.ofType) {
+        return resolveType(node.ofType);
+    }
+
+    if (node.type && node.type.ofType) {
+        return resolveType(node.type.ofType);
+    }
+
+    if (node.type) {
+        return resolveType(node.type);
+    }
+
+    return node;
+}
+
+function getFieldNumber(node: FieldNode | InputValueDefinitionNode) {
+    if (!node.directives) {
+        throw new Error(`No directives found on node ${node.name.value}`);
+    }
+
+    const fieldDirective = node.directives.find(dir => dir.name.value === 'field');
+    if (!fieldDirective) {
+        throw new Error(`No "field" directive found on node ${node.name.value}`);
+    }
+
+    // @ts-ignore Only ever has one argument right now:
+    return parseInt(fieldDirective.arguments[0].value.value, 10) - 1;
+}
+
+function getArgumentValue(argument: ArgumentNode, variables?: Variables) {
+    const resolvedValue =
+        argument.value.kind === 'Variable'
+            ? variables && variables[argument.value.name.value]
+            : argument.value.kind === 'NullValue'
+            ? null
+            : // TODO: Need more comprehensive argument checks:
+              (argument.value as any).value;
+
+    return resolvedValue ? Buffer.from(JSON.stringify(resolvedValue)) : null;
+}
+
+function walkSelections(ir: ChildIR, node: FieldNode, schemaNode: any, variables?: Variables) {
+    if (node.arguments && node.arguments.length) {
+        ir.arguments = ir.arguments || [];
+
+        for (const argument of node.arguments) {
+            const argNode = schemaNode.args.find((arg: any) => arg.name === argument.name.value);
+            const argNumber = getFieldNumber(argNode.astNode);
+
+            ir.arguments.push({
+                arg: argNumber,
+                value: getArgumentValue(argument, variables)
+            });
+        }
+    }
+
+    if (node.selectionSet) {
+        const schemaFields = resolveType(schemaNode).getFields();
+        node.selectionSet.selections.forEach(selection => {
+            if (selection.kind !== 'Field') {
+                throw new Error('Only field selections are currently supported.');
+            }
+
+            const fieldNode = schemaFields[selection.name.value];
+            const fieldNumber = getFieldNumber(fieldNode.astNode);
+
+            ir.fields |= 1 << fieldNumber;
+
+            // If there are arguments or selections, we need to create a dedicated node:
+            if (selection.selectionSet || (selection.arguments && selection.arguments.length)) {
+                ir.selections = ir.selections || [];
+
+                const nextIr: ChildIR = { id: fieldNumber, fields: 0 };
+                ir.selections.push(nextIr);
+
+                walkSelections(nextIr, selection, fieldNode, variables);
+            }
+        });
+    }
+}
+
+export default function createIR<Type>(
+    schema: GraphQLSchema,
+    query: string,
+    variables: Variables,
+    builder: {
+        getType(type: 'mutation' | 'subscription' | 'query'): Type;
+    }
+): IR<Type> {
+    const parsedQuery = parse(query);
+    const operationDefinition = parsedQuery.definitions[0] as OperationDefinitionNode;
+
+    const root: IR<Type> = {
+        type: builder.getType(operationDefinition.operation),
+        fields: 0
+    };
+
+    walkSelections(
+        (root as unknown) as ChildIR,
+        (operationDefinition as unknown) as FieldNode,
+        schema.getQueryType(),
+        variables
+    );
+
+    return root;
+}

--- a/packages/encoding/src/impl/avro.ts
+++ b/packages/encoding/src/impl/avro.ts
@@ -1,94 +1,45 @@
 import avro from 'avsc';
-import { parse, GraphQLSchema, OperationDefinitionNode, FieldNode } from 'graphql';
+import { GraphQLSchema } from 'graphql';
+import createIR from '../createIR';
+import { Variables } from '../types';
 
-export function encode(schema: GraphQLSchema, query: string) {
-    const Request = avro.Type.forSchema({
-        name: 'Request',
-        type: 'record',
-        fields: [
-            {
-                name: 'type',
-                type: ['null', { name: 'Type', type: 'enum', symbols: ['QUERY', 'MUTATION', 'SUBSCRIPTION'] }],
-                default: null
-            },
-            { name: 'field', type: ['null', 'int'], default: null },
-            { name: 'fields', type: 'long' },
-            { name: 'selections', type: ['null', { type: 'array', items: ['Request'] }], default: null }
-        ]
+export function encode(schema: GraphQLSchema, query: string, variables: Variables) {
+    const protocol = avro.readProtocol(`
+        protocol {
+            enum Type {
+                QUERY, MUTATION, SUBSCRIPTION
+            }
+
+            record Argument {
+                int arg;
+                bytes value;
+            }
+
+            record ChildSelection {
+                int id;
+                int fields;
+                union { null, array<ChildSelection> } selections = null;
+                union { null, array<Argument> } arguments = null;
+            }
+
+            record RequestSelection {
+                union { null, Type } type = null;
+                int fields;
+                union { null, array<ChildSelection> } selections = null;
+            }
+        }
+    `);
+
+    const Root = avro.Type.forSchema(protocol.types);
+    // @ts-ignore
+    const [_, __, ___, Request] = Root.types;
+
+    const ir = createIR(schema, query, variables, {
+        getType(type) {
+            if (type === 'query') return null;
+            return type.toUpperCase();
+        }
     });
 
-    const requestDescription: any = {
-        fields: 0
-    };
-
-    const parsedQuery = parse(query);
-
-    const operationDefinition = parsedQuery.definitions[0] as OperationDefinitionNode;
-
-    switch (operationDefinition.operation) {
-        case 'mutation':
-            requestDescription.type = 'MUTATION';
-            break;
-        case 'subscription':
-            requestDescription.type = 'SUBSCRIPTION';
-        case 'query':
-        default:
-            // requestDescription.type = 'QUERY';
-            break;
-    }
-
-    function walkSelections(selectionDescription: any, node: FieldNode, schemaNode: any) {
-        const selections = node.selectionSet!.selections;
-        const schemaFields = schemaNode.getFields();
-
-        selections.forEach(selection => {
-            if (selection.kind !== 'Field') {
-                throw new Error('Only field selections are currently supported.');
-            }
-
-            const selectionNode = schemaFields[selection.name.value];
-            const fieldDirective = selectionNode.astNode.directives.find(
-                (dir: any) => dir.name.value === 'field'
-            );
-            // Only ever has one argument right now:
-            const fieldNumber = parseInt(fieldDirective.arguments[0].value.value, 10) - 1;
-
-            selectionDescription.fields |= 1 << fieldNumber;
-
-            if (selection.selectionSet) {
-                if (!selectionDescription.selections) {
-                    selectionDescription.selections = [];
-                }
-
-                const data = { field: fieldNumber, fields: 0 };
-                selectionDescription.selections.push(data);
-
-                walkSelections(
-                    data,
-                    selection,
-                    resolveType(schemaNode.getFields()[selection.name.value])
-                );
-            }
-        });
-    }
-
-    function resolveType(node: any): any {
-        if (node.ofType) {
-            return resolveType(node.ofType);
-        }
-
-        if (node.type && node.type.ofType) {
-            return resolveType(node.type.ofType);
-        }
-
-        if (node.type) {
-            return resolveType(node.type);
-        }
-
-        return node;
-    }
-
-    walkSelections(requestDescription, operationDefinition as any, schema.getQueryType());
-
-    return Request.toBuffer(requestDescription);
+    return Request.toBuffer(ir);
 }

--- a/packages/encoding/src/impl/bespoke.ts
+++ b/packages/encoding/src/impl/bespoke.ts
@@ -1,125 +1,74 @@
-import path from 'path';
 import varint from 'varint';
-import { parse, GraphQLSchema, OperationDefinitionNode, FieldNode } from 'graphql';
+import { GraphQLSchema } from 'graphql';
+import createIR, { IR, ChildIR } from '../createIR';
+import { Variables } from '../types';
 
-function resolveType(node: any): any {
-    if (node.ofType) {
-        return resolveType(node.ofType);
-    }
-
-    if (node.type && node.type.ofType) {
-        return resolveType(node.type.ofType);
-    }
-
-    if (node.type) {
-        return resolveType(node.type);
-    }
-
-    return node;
-}
-
+// NOTE: Even though we never use 0, we still reserve it and don't use it for mutations to make it side-effect-free to zero-fill the buffer.
 const TYPE_QUERY = 0;
 const TYPE_MUTATION = 1;
 const TYPE_SUBSCRIPTION = 2;
-
 const FIELD_EXIT = 3;
-// Use an enter offset to make it unambiguous with query (0) mutation (1) subscription (2) and pop (3)
-const FIELD_ENTER_OFFSET = 4;
+const FIELD_ARGUMENT = 4;
+// Use an enter offset to make it unambiguous with query (0) mutation (1) subscription (2) exit (3) and arguments (4)
+const FIELD_ENTER_OFFSET = 6;
 
-export function encode(schema: GraphQLSchema, query: string) {
-    // TODO: Don't do fixed size:
+function stripTrailingExits(data: number[]) {
+    let i = data.length - 1;
+    while (data[i] === FIELD_EXIT) {
+        data.splice(i, 1);
+        i--;
+    }
+}
+
+export function encode(schema: GraphQLSchema, query: string, variables: Variables) {
     const data: number[] = [];
 
-    const requestDescription: any = {
-        fields: 0
-    };
-
-    const parsedQuery = parse(query);
-
-    const operationDefinition = parsedQuery.definitions[0] as OperationDefinitionNode;
-
-    function write(num: number) {
-        varint.encode(num).forEach(byte => {
-            data.push(byte);
-        });
-    }
-
-    function optimizeQuery() {
-        let i = data.length - 1;
-        while (data[i] === FIELD_EXIT) {
-            data.splice(i, 1);
-            i--;
+    function write(num: number | number[]) {
+        if (Array.isArray(num)) {
+            num.forEach(n => write(n));
+        } else {
+            varint.encode(num).forEach(byte => {
+                data.push(byte);
+            });
         }
     }
 
-    function walkSelections(selectionDescription: any, node: FieldNode, schemaNode: any) {
-        const selections = node.selectionSet!.selections;
-        const schemaFields = schemaNode.getFields();
-
-        selections.forEach((selection, i) => {
-            if (selection.kind !== 'Field') {
-                throw new Error('Only field selections are currently supported.');
-            }
-
-            const selectionNode = schemaFields[selection.name.value];
-            const fieldDirective = selectionNode.astNode.directives.find(
-                (dir: any) => dir.name.value === 'field'
-            );
-            // Only ever has one argument right now:
-            const fieldNumber = parseInt(fieldDirective.arguments[0].value.value, 10) - 1;
-
-            selectionDescription.fields |= 1 << fieldNumber;
-        });
-
-        write(selectionDescription.fields);
-
-        selections.forEach(selection => {
-            if (selection.kind !== 'Field') {
-                throw new Error('Only field selections are currently supported.');
-            }
-
-            const selectionNode = schemaFields[selection.name.value];
-            const fieldDirective = selectionNode.astNode.directives.find(
-                (dir: any) => dir.name.value === 'field'
-            );
-            // Only ever has one argument right now:
-            const fieldNumber = parseInt(fieldDirective.arguments[0].value.value, 10) - 1;
-
-            if (selection.selectionSet) {
-                write(fieldNumber + 1 + FIELD_ENTER_OFFSET);
-                if (!selectionDescription.selections) {
-                    selectionDescription.selections = [];
+    function walkIR(current: ChildIR | IR) {
+        write(current.fields);
+        if ('arguments' in current && current.arguments) {
+            write(FIELD_ARGUMENT);
+            for (const argument of current.arguments) {
+                write(argument.arg);
+                // TODO: Really should get better null handling:
+                write(argument.value ? argument.value.length : 0);
+                if (argument.value) {
+                    write([...argument.value]);
                 }
+            }
+        }
 
-                const data = { field: fieldNumber, fields: 0 };
-                selectionDescription.selections.push(data);
-
-                walkSelections(
-                    data,
-                    selection,
-                    resolveType(schemaNode.getFields()[selection.name.value])
-                );
-
+        if (current.selections) {
+            for (const selection of current.selections) {
+                write(FIELD_ENTER_OFFSET + selection.id);
+                walkIR(selection);
                 write(FIELD_EXIT);
             }
-        });
+        }
     }
 
-    walkSelections(requestDescription, operationDefinition as any, schema.getQueryType());
+    const ir = createIR(schema, query, variables, {
+        getType: type => type
+    });
 
-    switch (operationDefinition.operation) {
+    walkIR(ir);
+    stripTrailingExits(data);
+
+    switch (ir.type) {
         case 'mutation':
             write(TYPE_MUTATION);
             break;
         case 'subscription':
             write(TYPE_SUBSCRIPTION);
-            break;
-        case 'query':
-            // For query, we can actually optimize by ditching any trailing pops:
-            optimizeQuery();
-            break;
-        default:
-            throw new Error();
             break;
     }
 
@@ -137,7 +86,7 @@ function decode(data: number[]) {
 
         if (data[offset]) {
             // We're pushing a field:
-            if (data[offset] > FIELD_ENTER_OFFSET) {
+            if (data[offset] >= FIELD_ENTER_OFFSET) {
                 selection.children = selection.children || {};
                 const field = varint.decode(data, offset) - FIELD_ENTER_OFFSET;
                 offset += varint.decode.bytes;

--- a/packages/encoding/src/impl/json.ts
+++ b/packages/encoding/src/impl/json.ts
@@ -1,12 +1,13 @@
 import { GraphQLSchema } from 'graphql';
 import compress from 'graphql-query-compress';
+import { Variables } from '../types';
 
 type RequestBody = {
     query: string;
     variables?: any;
 };
 
-export function encode(_schema: GraphQLSchema, query: string, variables?: any) {
+export function encode(_schema: GraphQLSchema, query: string, variables: Variables) {
     const obj: RequestBody = {
         query: compress(query)
     };

--- a/packages/encoding/src/impl/msgpack.ts
+++ b/packages/encoding/src/impl/msgpack.ts
@@ -1,82 +1,38 @@
 import msgpack from 'msgpack5';
-import { parse, GraphQLSchema, OperationDefinitionNode, FieldNode, GraphQLField } from 'graphql';
+import { GraphQLSchema } from 'graphql';
+import createIR, { IR } from '../createIR';
+import { Variables } from '../types';
 
-export function encode(schema: GraphQLSchema, query: string) {
-    const parsedQuery = parse(query);
+function optimizeIR(ir: IR) {
+    let optimized: any = ir;
+
+    if (ir.selections) {
+        ir.selections.forEach(selection => optimizeIR(selection));
+    }
+
+    if (ir.arguments) {
+        ir.arguments.forEach(arg => optimizeIR(arg));
+    }
+
+    Object.keys(ir).forEach(key => {
+        if (key.length > 1) {
+            optimized[key.charAt(0)] = optimized[key];
+            delete optimized[key];
+        }
+    });
+}
+
+export function encode(schema: GraphQLSchema, query: string, variables: Variables) {
     const encoder = msgpack();
 
-    const payload: any = {};
-
-    const operationDefinition = parsedQuery.definitions[0] as OperationDefinitionNode;
-
-    switch (operationDefinition.operation) {
-        case 'mutation':
-            payload.t = 1;
-            break;
-        case 'subscription':
-            payload.t = 2;
-        case 'query':
-        default:
-            // Do nothing, default is query:
-            break;
-    }
-
-    payload.s = { f: 0 };
-
-    function walkSelections(s: any, node: FieldNode, schemaNode: any) {
-        const selections = node.selectionSet!.selections;
-
-        // console.log(schemaNode);
-        const schemaFields = schemaNode.getFields();
-
-        selections.forEach((selection, i) => {
-            if (selection.kind !== 'Field') {
-                throw new Error('Only field selections are currently supported.');
-            }
-
-            const selectionNode = schemaFields[selection.name.value];
-            const fieldDirective = selectionNode.astNode.directives.find((dir: any) => dir.name.value === 'field');
-            // @ts-ignore Only has one argument right now:
-            const fieldNumber = parseInt(fieldDirective!.arguments[0].value.value, 10) - 1;
-
-            s.f |= (1 << fieldNumber);
-
-            if (selection.selectionSet) {
-                if (!s.s) {
-                    s.s = {};
-                }
-
-                if (!s.s[fieldNumber]) {
-                    s.s[fieldNumber] = { f: 0 };
-                }
-
-                walkSelections(s.s[fieldNumber], selection, resolveType(schemaNode.getFields()[selection.name.value]));
-            }
-        });
-    }
-
-    function resolveType(node: any): any {
-        if (node.ofType) {
-            return resolveType(node.ofType);
+    const ir = createIR(schema, query, variables, {
+        getType(type) {
+            if (type === 'mutation') return 1;
+            if (type === 'subscription') return 2;
         }
+    });
 
-        if (node.type && node.type.ofType) {
-            return resolveType(node.type.ofType);
-        }
+    optimizeIR(ir);
 
-        if (node.type) {
-            return resolveType(node.type);
-        }
-
-        return node;
-    }
-
-    walkSelections(payload.s, operationDefinition as any, schema.getQueryType());
-
-    return Buffer.from(
-        encoder
-            .encode(payload)
-            .toString('hex'),
-        'hex'
-    );
+    return Buffer.from(encoder.encode(ir).toString('hex'), 'hex');
 }

--- a/packages/encoding/src/impl/proto.ts
+++ b/packages/encoding/src/impl/proto.ts
@@ -1,117 +1,19 @@
 import path from 'path';
 import protobuf from 'protobufjs';
-import {
-    parse,
-    GraphQLSchema,
-    OperationDefinitionNode,
-    FieldNode,
-    InputValueDefinitionNode
-} from 'graphql';
+import { GraphQLSchema } from 'graphql';
+import createIR from '../createIR';
+import { Variables } from '../types';
 
-export function encode(schema: GraphQLSchema, query: string, variables?: any) {
+export function encode(schema: GraphQLSchema, query: string, variables: Variables) {
     const root = protobuf.loadSync(path.join(__dirname, 'request.proto'));
     const Request = root.lookupType('RequestSelection');
 
-    const requestDescription: any = {
-        fields: 0
-    };
-
-    const parsedQuery = parse(query);
-
-    const operationDefinition = parsedQuery.definitions[0] as OperationDefinitionNode;
-
-    switch (operationDefinition.operation) {
-        case 'mutation':
-            requestDescription.type = 1;
-            break;
-        case 'subscription':
-            requestDescription.type = 2;
-        case 'query':
-        default:
-            // Do nothing, default is 0, which is query:
-            break;
-    }
-
-    function getFieldNumber(node: FieldNode | InputValueDefinitionNode) {
-        if (!node.directives) {
-            throw new Error(`No directives found on node ${node.name.value}`);
+    const ir = createIR(schema, query, variables, {
+        getType(type) {
+            if (type === 'mutation') return 1;
+            if (type === 'subscription') return 2;
         }
+    });
 
-        const fieldDirective = node.directives.find(dir => dir.name.value === 'field');
-        if (!fieldDirective) {
-            throw new Error(`No "field" directive found on node ${node.name.value}`);
-        }
-
-        // @ts-ignore Only ever has one argument right now:
-        return parseInt(fieldDirective.arguments[0].value.value, 10) - 1;
-    }
-
-    // TODO: Use graphql visit:
-    function walkSelections(selectionDescription: any, node: FieldNode, schemaNode: any) {
-        const selections = node.selectionSet!.selections;
-        const schemaFields = schemaNode.getFields();
-
-        selections.forEach(selection => {
-            if (selection.kind !== 'Field') {
-                throw new Error('Only field selections are currently supported.');
-            }
-
-            const fieldNode = schemaFields[selection.name.value];
-            const fieldNumber = getFieldNumber(fieldNode.astNode);
-
-            selectionDescription.fields |= 1 << fieldNumber;
-
-            if (selection.arguments && selection.arguments.length) {
-                selectionDescription.arguments = selectionDescription.arguments || [];
-
-                selection.arguments.forEach(argument => {
-                    const argNode = fieldNode.args.find(
-                        (arg: any) => arg.name === argument.name.value
-                    );
-                    const argNumber = getFieldNumber(argNode.astNode);
-                    const value =
-                        argument.value.kind === 'Variable'
-                            ? variables[argument.value.name.value]
-                            : argument.value.kind === 'NullValue'
-                            ? null
-                            // @ts-ignore Need to build a comprehensive value extractor:
-                            : argument.value.value;
-
-                    selectionDescription.arguments.push({
-                        arg: argNumber,
-                        value: value ? Buffer.from(JSON.stringify(value)) : null
-                    });
-                });
-            }
-
-            if (selection.selectionSet) {
-                selectionDescription.selections = selectionDescription.selections || [];
-
-                const data = { field: fieldNumber, fields: 0 };
-                selectionDescription.selections.push(data);
-
-                walkSelections(data, selection, resolveType(fieldNode));
-            }
-        });
-    }
-
-    function resolveType(node: any): any {
-        if (node.ofType) {
-            return resolveType(node.ofType);
-        }
-
-        if (node.type && node.type.ofType) {
-            return resolveType(node.type.ofType);
-        }
-
-        if (node.type) {
-            return resolveType(node.type);
-        }
-
-        return node;
-    }
-
-    walkSelections(requestDescription, operationDefinition as any, schema.getQueryType());
-
-    return Request.encode(Request.fromObject(requestDescription)).finish();
+    return Request.encode(Request.fromObject(ir)).finish();
 }

--- a/packages/encoding/src/impl/request.proto
+++ b/packages/encoding/src/impl/request.proto
@@ -3,8 +3,7 @@ syntax = "proto3";
 enum Type {
     QUERY = 0;
     MUTATION = 1;
-    // TODO: Add subscription support.
-    // SUBSCRIPTION = 2;
+    SUBSCRIPTION = 2;
 }
 
 message Argument {
@@ -13,7 +12,7 @@ message Argument {
 }
 
 message ChildSelection {
-  uint32 field = 1;
+  uint32 id = 1;
   uint64 fields = 2;
   repeated ChildSelection selections = 3 [packed=true];
   repeated Argument arguments = 4 [packed=true];

--- a/packages/encoding/src/types.ts
+++ b/packages/encoding/src/types.ts
@@ -1,0 +1,1 @@
+export type Variables = Record<string, any> | undefined | null;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
         "strict": true,
         "lib": ["esnext"],
         "moduleResolution": "node",
-        "outDir": "lib"
+        "outDir": "lib",
+        "downlevelIteration": true
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -616,13 +616,6 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-avro-js@^1.8.2:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/avro-js/-/avro-js-1.8.2.tgz#915d1cf4497261e76496147f3e6b9c4a6f678329"
-  integrity sha1-kV0c9ElyYedklhR/PmucSm9ngyk=
-  dependencies:
-    underscore "*"
-
 avsc@^5.4.7:
   version "5.4.7"
   resolved "https://registry.yarnpkg.com/avsc/-/avsc-5.4.7.tgz#7036f16334ba04207343d3a53896d52c7da41deb"
@@ -3662,11 +3655,6 @@ uglify-js@^3.1.4:
   dependencies:
     commander "~2.20.0"
     source-map "~0.6.1"
-
-underscore@*:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
-  integrity sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==
 
 union-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This unifies all of the intermediate representations so that there's just a single builder for the IR, and then each encoding just consumes it. This makes comparisons more equal, and also makes it easier to create new encoding types.

I updates all of the encoding formats to accept arguments.