### PR TITLE
Use field order instead of directive

### DIFF
--- a/packages/encoding/src/__tests__/fixtures/minimal/schema.graphql
+++ b/packages/encoding/src/__tests__/fixtures/minimal/schema.graphql
@@ -1,16 +1,31 @@
 # TODO: Use prelude:
 directive @field(id: Int!) on FIELD_DEFINITION | ENUM_VALUE | ARGUMENT_DEFINITION
 
+# NOTE: Uncomment to use directive-based numbering:
+# type Query {
+#     message: String! @field(id: 1)
+#     me: User @field(id: 2)
+#     user(id: Int! @field(id: 1), cursor: String! @field(id: 2)): User @field(id: 3)
+# }
+
+# type User {
+#     id: Int! @field(id: 1)
+#     name: String! @field(id: 2)
+#     email: String! @field(id: 3)
+#     friends: [User!]! @field(id: 4)
+#     description(format: String! @field(id: 1)): String! @field(id: 5)
+# }
+
 type Query {
-    message: String! @field(id: 1)
-    me: User @field(id: 2)
-    user(id: Int! @field(id: 1), cursor: String! @field(id: 2)): User @field(id: 3)
+    message: String!
+    me: User
+    user(id: Int!, cursor: String!): User
 }
 
 type User {
-    id: Int! @field(id: 1)
-    name: String! @field(id: 2)
-    email: String! @field(id: 3)
-    friends: [User!]! @field(id: 4)
-    description(format: String! @field(id: 1)): String! @field(id: 5)
+    id: Int!
+    name: String!
+    email: String!
+    friends: [User!]!
+    description(format: String!): String!
 }

--- a/packages/encoding/src/createIR.ts
+++ b/packages/encoding/src/createIR.ts
@@ -42,19 +42,20 @@ function resolveType(node: any): any {
     return node;
 }
 
-function getFieldNumber(node: FieldNode | InputValueDefinitionNode) {
-    if (!node.directives) {
-        throw new Error(`No directives found on node ${node.name.value}`);
-    }
+// NOTE: Uncomment to use directive-based numbering:
+// function getFieldNumber(node: FieldNode | InputValueDefinitionNode) {
+    // if (!node.directives) {
+    //     throw new Error(`No directives found on node ${node.name.value}`);
+    // }
 
-    const fieldDirective = node.directives.find(dir => dir.name.value === 'field');
-    if (!fieldDirective) {
-        throw new Error(`No "field" directive found on node ${node.name.value}`);
-    }
+    // const fieldDirective = node.directives.find(dir => dir.name.value === 'field');
+    // if (!fieldDirective) {
+    //     throw new Error(`No "field" directive found on node ${node.name.value}`);
+    // }
 
-    // @ts-ignore Only ever has one argument right now:
-    return parseInt(fieldDirective.arguments[0].value.value, 10) - 1;
-}
+    // // @ts-ignore Only ever has one argument right now:
+    // return parseInt(fieldDirective.arguments[0].value.value, 10) - 1;
+// }
 
 function getArgumentValue(argument: ArgumentNode, variables?: Variables) {
     const resolvedValue =
@@ -73,8 +74,10 @@ function walkSelections(ir: ChildIR, node: FieldNode, schemaNode: any, variables
         ir.arguments = ir.arguments || [];
 
         for (const argument of node.arguments) {
-            const argNode = schemaNode.args.find((arg: any) => arg.name === argument.name.value);
-            const argNumber = getFieldNumber(argNode.astNode);
+            const argNumber = schemaNode.args.findIndex((arg: any) => arg.name === argument.name.value);
+            // NOTE: Uncomment to use directive-based numbering:
+            // const argNode = schemaNode.args.find((arg: any) => arg.name === argument.name.value);
+            // const argNumber = getFieldNumber(argNode.astNode);
 
             ir.arguments.push({
                 arg: argNumber,
@@ -91,7 +94,9 @@ function walkSelections(ir: ChildIR, node: FieldNode, schemaNode: any, variables
             }
 
             const fieldNode = schemaFields[selection.name.value];
-            const fieldNumber = getFieldNumber(fieldNode.astNode);
+            const fieldNumber = Object.keys(schemaFields).findIndex((field) => field === selection.name.value);
+            // NOTE: Uncomment to use directive-based numbering:
+            // const fieldNumber = getFieldNumber(fieldNode.astNode);
 
             ir.fields |= 1 << fieldNumber;
 


### PR DESCRIPTION
This changes to use the field order instead of a directive to denote the ID of given fields.

I'm not 100% sure this will be how things are done, but I do think there's value in making this work _out-of-the-box_ for GraphQL schemas.